### PR TITLE
remove sql statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ Once in the mysql shell execute the following commands, assumption is made $your
 ````
 DROP DATABASE $yourdatabase;
 CREATE DATABASE $yourdatabase;
-ALTER DATABASE $yourdatabase CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-GRANT ALL PRIVILEGES ON $yourdatabase.* TO '$youruser'@'localhost';
 FLUSH PRIVILEGES;
 ````
 Start node again, wait till sync is complete. 


### PR DESCRIPTION
... which aren't required anymore.
per default all tables are created in the right collation: https://github.com/PoC-Consortium/burstcoin/blob/master/src/brs/db/mariadb/MariadbDbVersion.java#L90

regranting isn't required aswell, as mysql stores the right as long as you don't delete them.